### PR TITLE
Add multi-tenant site management Flutter app with mock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
-# aa
-açıklama
+# Site & Aidat Yönetimi Mobil Uygulaması
+
+Bu repo, Flutter + Clean Architecture yaklaşımıyla geliştirilen çok kiracılı (multi-tenant) **Site & Aidat Yönetimi** uygulamasını ve beraberindeki mock API'yi içerir. Uygulama; dönem bazlı masraf dağıtımı, fatura üretimi, çevrimdışı senkronizasyon, rol yönetimi, FCM bildirimleri, PDF çıktısı ve pazar yeri ödeme altyapılarına entegrasyon için gerekli soyutlamaları örnekler.
+
+## Mimarinin Özeti
+
+- **Sunum Katmanı (Presentation)**: Riverpod tabanlı durumsal yönetim (`SiteController`) ve Material 3 arayüz bileşenleri.
+- **Domain Katmanı**: Entity, repository sözleşmeleri ve use-case'ler (`GetSite`, `RunPeriod`, `PublishPeriod`, `CreatePaymentIntent`, vb.).
+- **Veri Katmanı**: `SiteRepositoryImpl` ile mock API'den veri alma, çevrimdışı önbellek (`OfflineCache`) ve idempotent senkron kuyruğu.
+- **Çekirdek**: JWT yönetimi, HTTP istemcisi, PDF üretimi (Türkçe karakter desteği için TrueType font), bildirim servisi (FCM), hata modelleri.
+- **Mock API**: FastAPI ile yazılmış çok kiracılı uç noktalar, masraf dağıtım seçeneklerinin (arsa payı, m², sabit, sayaç) tamamını destekler.
+
+## Özellikler
+
+- Dönem -> çalışma -> yayınlama -> fatura üretim akışı.
+- Kalem bazlı masraf dağıtım tipleri: arsa payı, metrekare, sabit tutar, sayaç okuması.
+- Faturalar için UUID tabanlı tekillik (`invoice_id`).
+- İyzico / PayTR benzeri pazar yeri ödeme entegrasyonuna hazırlık yapan `PaymentIntent` modellemesi ve platform komisyonu ayrımı için altyapı.
+- Firebase Messaging ile FCM bildirimleri, Firebase Core başlatma.
+- Çevrimdışı cache + idempotent senkron kuyruğu (`OfflineCache`).
+- Roller: `superadmin`, `site_yoneticisi`, `muhasebe`, `personel`, `sakin`.
+- Türkçe karakter uyumlu PDF çıktısı (`InvoicePdfGenerator`).
+- JWT saklama ve yenileme kontrolü (`JwtTokenManager`).
+- Mock testler (`flutter_test`, `mocktail`).
+
+## Kurulum
+
+### 1. Flutter ortamı
+
+```bash
+flutter pub get
+```
+
+Varsayılan olarak `lib/main.dart` Firebase'i başlatır; test veya geliştirme ortamında `firebase_options.dart` gereksinimini kaldırmak için `Firebase.initializeApp()` çağrısını koşullu hale getirebilirsiniz.
+
+### 2. Mock API'yi çalıştırma
+
+Mock API, `mock_api/server.py` içinde FastAPI ile sağlanır.
+
+```bash
+cd mock_api
+python -m venv .venv
+source .venv/bin/activate
+pip install fastapi uvicorn
+uvicorn server:app --reload --host 0.0.0.0 --port 8000
+```
+
+### 3. Uygulamayı başlatma
+
+```bash
+flutter run -d ios    # veya
+flutter run -d android
+```
+
+Uygulama açıldığında Riverpod provider zinciri `demo-site` kiracısını yükler ve dönem/masraf örneklerini listeler.
+
+## Testler
+
+```bash
+flutter test
+```
+
+## Çevrimdışı Senkron ve Idempotency
+
+- Her başarısız ağ isteği `ApiClient` içinde SharedPreferences tabanlı kuyruğa yazılır.
+- `OfflineCache` birincil anahtar üretimini UUID ile sağlar, tekrar eden istekler idempotent şekilde saklanır.
+- `SiteLocalDataSource` kuyruğu dışarı aktarır; gerçek projede arka plan senkron servisi ile işlenebilir.
+
+## Bildirimler
+
+`NotificationService`, Firebase Cloud Messaging izinlerini ister ve `site-updates` konusuna abone olur. Use-case çağrıları başarıyla tamamlandığında log tabanlı bildirim tetiklenir; gerçek uygulamada `flutter_local_notifications` ile görsel bildirim gösterilebilir.
+
+## PDF
+
+`core/utils/pdf_generator.dart` dosyası Syncfusion PDF paketini kullanarak Türkçe karakter desteği sağlayan TrueType font ile fatura PDF'i üretir. `assets/fonts/Roboto-Regular.ttf` gibi bir font dosyasını `pubspec.yaml`'a eklemeyi unutmayın.
+
+## Güvenlik
+
+`JwtTokenManager`, SharedPreferences üzerinde JWT saklarken `exp` alanını kontrol eder; süresi dolan token'ı temizler. API çağrıları otomatik olarak `Authorization: Bearer` başlığı ile yapılır.
+
+## Lisans
+
+MIT

--- a/assets/fonts/README.txt
+++ b/assets/fonts/README.txt
@@ -1,0 +1,1 @@
+Bu klasöre Türkçe karakter destekli TrueType font (ör. Roboto) ekleyin ve dosya adını `InvoicePdfGenerator` içerisinde güncelleyin.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'di/providers.dart';
+import 'features/site_management/domain/entities/expense.dart';
+import 'features/site_management/domain/entities/period.dart';
+import 'features/site_management/domain/entities/invoice.dart';
+import 'features/site_management/domain/entities/site.dart';
+import 'features/site_management/presentation/controllers/site_controller.dart';
+import 'features/site_management/presentation/state/site_state.dart';
+
+class SiteApp extends ConsumerStatefulWidget {
+  const SiteApp({super.key});
+
+  @override
+  ConsumerState<SiteApp> createState() => _SiteAppState();
+}
+
+class _SiteAppState extends ConsumerState<SiteApp> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(notificationServiceProvider).initialize();
+      ref.read(siteControllerProvider.notifier).loadSite('demo-site');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+      useMaterial3: true,
+    );
+    return MaterialApp(
+      title: 'Site & Aidat Yönetimi',
+      theme: theme,
+      home: const SiteDashboardPage(),
+    );
+  }
+}
+
+class SiteDashboardPage extends ConsumerWidget {
+  const SiteDashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(siteControllerProvider);
+    final controller = ref.read(siteControllerProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(state.site?.name ?? 'Site & Aidat Yönetimi'),
+      ),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: () async {
+                final siteId = state.site?.id ?? 'demo-site';
+                await controller.loadSite(siteId);
+              },
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  if (state.errorMessage != null)
+                    Card(
+                      color: Colors.red.shade50,
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Text(
+                          state.errorMessage!,
+                          style: const TextStyle(color: Colors.red),
+                        ),
+                      ),
+                    ),
+                  if (state.site != null)
+                    _RolesSection(roles: state.site!.roles),
+                  const SizedBox(height: 16),
+                  _PeriodList(
+                    periods: state.periods,
+                    onRun: (period) async {
+                      final siteId = state.site?.id ?? 'demo-site';
+                      await controller.runPeriod(siteId, period);
+                    },
+                    onPublish: (period) async {
+                      final siteId = state.site?.id ?? 'demo-site';
+                      await controller.publishPeriod(siteId, period.id);
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  _InvoiceList(
+                    invoices: state.invoices,
+                    onCollect: (invoice) async {
+                      final siteId = state.site?.id ?? 'demo-site';
+                      await controller.collectPayment(
+                        siteId,
+                        invoice.id,
+                        'iyzico',
+                      );
+                    },
+                    onMarkPaid: (invoice) async {
+                      final siteId = state.site?.id ?? 'demo-site';
+                      await controller.markInvoicePaid(siteId, invoice.id);
+                    },
+                  ),
+                ],
+              ),
+            ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          final site = state.site ??
+              Site(id: 'demo-site', name: 'Demo Site', units: const [], roles: const []);
+          final newPeriod = Period(
+            id: DateTime.now().millisecondsSinceEpoch.toString(),
+            name: 'Yeni Dönem',
+            siteId: site.id,
+            expenses: const [
+              ExpenseItem(
+                id: 'exp-1',
+                name: 'Genel Temizlik',
+                amount: 15000,
+                distributionType: ExpenseDistributionType.squareMeter,
+              ),
+            ],
+            status: PeriodStatus.draft,
+          );
+          controller.runPeriod(site.id, newPeriod);
+        },
+        child: const Icon(Icons.play_circle_outline),
+      ),
+    );
+  }
+}
+
+class _RolesSection extends StatelessWidget {
+  const _RolesSection({required this.roles});
+
+  final List<String> roles;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Roller',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: roles
+                  .map((role) => Chip(
+                        label: Text(role.replaceAll('_', ' ')),
+                      ))
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PeriodList extends StatelessWidget {
+  const _PeriodList({
+    required this.periods,
+    required this.onRun,
+    required this.onPublish,
+  });
+
+  final List<Period> periods;
+  final ValueChanged<Period> onRun;
+  final ValueChanged<Period> onPublish;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Dönemler',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        if (periods.isEmpty)
+          const Text('Henüz dönem bulunmuyor'),
+        ...periods.map((period) => Card(
+              child: ListTile(
+                title: Text(period.name),
+                subtitle: Text('Durum: ${period.status.name}'),
+                trailing: Wrap(
+                  spacing: 8,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.calculate_outlined),
+                      onPressed: () => onRun(period),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.publish_outlined),
+                      onPressed: () => onPublish(period),
+                    ),
+                  ],
+                ),
+              ),
+            )),
+      ],
+    );
+  }
+}
+
+class _InvoiceList extends StatelessWidget {
+  const _InvoiceList({
+    required this.invoices,
+    required this.onCollect,
+    required this.onMarkPaid,
+  });
+
+  final List<Invoice> invoices;
+  final ValueChanged<Invoice> onCollect;
+  final ValueChanged<Invoice> onMarkPaid;
+
+  @override
+  Widget build(BuildContext context) {
+    if (invoices.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Faturalar',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        ...invoices.map((invoice) => Card(
+              child: ListTile(
+                title: Text('${invoice.tenantName} - ${invoice.total.toStringAsFixed(2)} ₺'),
+                subtitle: Text('Durum: ${invoice.paymentStatus}'),
+                trailing: Wrap(
+                  spacing: 8,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.payment),
+                      onPressed: () => onCollect(invoice),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.check_circle_outline),
+                      onPressed: () => onMarkPaid(invoice),
+                    ),
+                  ],
+                ),
+              ),
+            )),
+      ],
+    );
+  }
+}

--- a/lib/core/auth/jwt_token_manager.dart
+++ b/lib/core/auth/jwt_token_manager.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class JwtTokenManager {
+  JwtTokenManager(this._prefs);
+
+  final SharedPreferences _prefs;
+  static const _tokenKey = 'jwt_token';
+
+  Future<void> saveToken(String token) async {
+    final payload = _decodePayload(token);
+    final expiresAt = payload['exp'] as int?;
+    await _prefs.setString(_tokenKey, token);
+    if (expiresAt != null) {
+      await _prefs.setInt('${_tokenKey}_exp', expiresAt);
+    }
+  }
+
+  Future<String?> getToken() async {
+    final token = _prefs.getString(_tokenKey);
+    final expiresAt = _prefs.getInt('${_tokenKey}_exp');
+    if (token == null) {
+      return null;
+    }
+    if (expiresAt != null) {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      if (now > expiresAt) {
+        await clear();
+        return null;
+      }
+    }
+    return token;
+  }
+
+  Future<void> clear() async {
+    await _prefs.remove(_tokenKey);
+    await _prefs.remove('${_tokenKey}_exp');
+  }
+
+  Map<String, dynamic> _decodePayload(String token) {
+    final parts = token.split('.');
+    if (parts.length != 3) {
+      return <String, dynamic>{};
+    }
+    final normalized = base64.normalize(parts[1]);
+    final payload = utf8.decode(base64Url.decode(normalized));
+    return jsonDecode(payload) as Map<String, dynamic>;
+  }
+}

--- a/lib/core/cache/offline_cache.dart
+++ b/lib/core/cache/offline_cache.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+class OfflineCacheQueueItem {
+  OfflineCacheQueueItem({
+    required this.key,
+    required this.payload,
+  });
+
+  final String key;
+  final Map<String, dynamic> payload;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'key': key,
+        'payload': payload,
+      };
+
+  static OfflineCacheQueueItem fromJson(Map<String, dynamic> json) {
+    return OfflineCacheQueueItem(
+      key: json['key'] as String,
+      payload: Map<String, dynamic>.from(json['payload'] as Map),
+    );
+  }
+}
+
+class OfflineCache {
+  OfflineCache(this._prefs);
+
+  final SharedPreferences _prefs;
+  static const _queueKey = 'offline_queue';
+
+  Future<void> enqueue(Map<String, dynamic> payload) async {
+    final queue = await _load();
+    queue.add(
+      OfflineCacheQueueItem(
+        key: const Uuid().v4(),
+        payload: payload,
+      ),
+    );
+    await _save(queue);
+  }
+
+  Future<List<OfflineCacheQueueItem>> fetch() async {
+    return _load();
+  }
+
+  Future<void> clearItem(String key) async {
+    final queue = await _load();
+    queue.removeWhere((item) => item.key == key);
+    await _save(queue);
+  }
+
+  Future<List<OfflineCacheQueueItem>> _load() async {
+    final value = _prefs.getString(_queueKey);
+    if (value == null) {
+      return <OfflineCacheQueueItem>[];
+    }
+    final decoded = jsonDecode(value) as List;
+    return decoded
+        .map((dynamic item) => OfflineCacheQueueItem.fromJson(
+              Map<String, dynamic>.from(item as Map),
+            ))
+        .toList();
+  }
+
+  Future<void> _save(List<OfflineCacheQueueItem> queue) async {
+    await _prefs.setString(
+      _queueKey,
+      jsonEncode(queue.map((item) => item.toJson()).toList()),
+    );
+  }
+}

--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -1,0 +1,21 @@
+abstract class Failure {
+  const Failure({this.message});
+
+  final String? message;
+}
+
+class NetworkFailure extends Failure {
+  const NetworkFailure({super.message});
+}
+
+class CacheFailure extends Failure {
+  const CacheFailure({super.message});
+}
+
+class ValidationFailure extends Failure {
+  const ValidationFailure({super.message});
+}
+
+class AuthenticationFailure extends Failure {
+  const AuthenticationFailure({super.message});
+}

--- a/lib/core/network/api_client.dart
+++ b/lib/core/network/api_client.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../auth/jwt_token_manager.dart';
+
+class ApiClient {
+  ApiClient(this._dio, this._tokenManager);
+
+  final Dio _dio;
+  final JwtTokenManager _tokenManager;
+
+  Future<Response<T>> get<T>(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    return _request<T>(
+      () => _dio.get(
+        path,
+        queryParameters: queryParameters,
+        options: await _authorizedOptions(),
+      ),
+    );
+  }
+
+  Future<Response<T>> post<T>(
+    String path, {
+    Object? data,
+  }) async {
+    return _request<T>(
+      () => _dio.post(
+        path,
+        data: data,
+        options: await _authorizedOptions(),
+      ),
+    );
+  }
+
+  Future<Response<T>> put<T>(
+    String path, {
+    Object? data,
+  }) async {
+    return _request<T>(
+      () => _dio.put(
+        path,
+        data: data,
+        options: await _authorizedOptions(),
+      ),
+    );
+  }
+
+  Future<Response<T>> _request<T>(Future<Response<T>> Function() handler) async {
+    try {
+      final response = await handler();
+      return response;
+    } on DioException catch (error) {
+      final requestOptions = error.requestOptions;
+      final prefs = await SharedPreferences.getInstance();
+      final offlineKey = 'offline_${requestOptions.method}_${requestOptions.path}';
+      await prefs.setString(
+        offlineKey,
+        jsonEncode(
+          <String, dynamic>{
+            'data': requestOptions.data,
+            'headers': requestOptions.headers,
+            'timestamp': DateTime.now().toIso8601String(),
+          },
+        ),
+      );
+      rethrow;
+    }
+  }
+
+  Future<Options> _authorizedOptions() async {
+    final token = await _tokenManager.getToken();
+    return Options(
+      headers: <String, dynamic>{
+        if (token != null) 'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      },
+    );
+  }
+}

--- a/lib/core/usecases/usecase.dart
+++ b/lib/core/usecases/usecase.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+
+import '../errors/failures.dart';
+
+typedef EitherFailureOr<T> = Future<Either<Failure, T>>;
+
+typedef StreamEitherFailureOr<T> = Stream<Either<Failure, T>>;
+
+abstract class UseCase<Type, Params> {
+  EitherFailureOr<Type> call(Params params);
+}
+
+class NoParams {
+  const NoParams();
+}

--- a/lib/core/utils/notification_service.dart
+++ b/lib/core/utils/notification_service.dart
@@ -1,0 +1,18 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+class NotificationService {
+  NotificationService(this._messaging);
+
+  final FirebaseMessaging _messaging;
+
+  Future<void> initialize() async {
+    await _messaging.requestPermission();
+    await _messaging.subscribeToTopic('site-updates');
+  }
+
+  Future<void> sendLocalLog(String message) async {
+    // In a real app this would show a local notification. Here we log the intent.
+    // ignore: avoid_print
+    print('Bildirim gönderildi: $message');
+  }
+}

--- a/lib/core/utils/pdf_generator.dart
+++ b/lib/core/utils/pdf_generator.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:syncfusion_flutter_pdf/pdf.dart';
+
+import '../../features/site_management/domain/entities/invoice.dart';
+
+class InvoicePdfGenerator {
+  Future<Uint8List> build(Invoice invoice) async {
+    final document = PdfDocument();
+    final page = document.pages.add();
+    final content = page.graphics;
+
+    final fontData = await rootBundle.load('assets/fonts/Roboto-Regular.ttf');
+    final font = PdfTrueTypeFont(
+      fontData.buffer.asUint8List(),
+      12,
+      fontStyle: PdfFontStyle.regular,
+    );
+
+    final format = NumberFormat.currency(locale: 'tr_TR', symbol: '₺');
+
+    content.drawString(
+      'Fatura ID: ${invoice.id}',
+      font,
+      bounds: const Rect.fromLTWH(0, 0, 500, 20),
+    );
+    content.drawString(
+      'Dönem: ${invoice.periodName}',
+      font,
+      bounds: const Rect.fromLTWH(0, 20, 500, 20),
+    );
+    content.drawString(
+      'Sakin: ${invoice.tenantName}',
+      font,
+      bounds: const Rect.fromLTWH(0, 40, 500, 20),
+    );
+
+    double offset = 80;
+    for (final item in invoice.items) {
+      content.drawString(
+        '- ${item.description}: ${format.format(item.amount)}',
+        font,
+        bounds: Rect.fromLTWH(0, offset, 500, 20),
+      );
+      offset += 20;
+    }
+
+    content.drawString(
+      'Toplam: ${format.format(invoice.total)}',
+      font,
+      bounds: Rect.fromLTWH(0, offset + 10, 500, 20),
+    );
+
+    final bytes = await document.save();
+    document.dispose();
+    return bytes;
+  }
+}

--- a/lib/di/providers.dart
+++ b/lib/di/providers.dart
@@ -1,0 +1,122 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+import '../core/auth/jwt_token_manager.dart';
+import '../core/cache/offline_cache.dart';
+import '../core/network/api_client.dart';
+import '../features/site_management/data/datasources/site_local_data_source.dart';
+import '../features/site_management/data/datasources/site_remote_data_source.dart';
+import '../features/site_management/data/repositories/site_repository_impl.dart';
+import '../features/site_management/domain/repositories/site_repository.dart';
+import '../features/site_management/domain/usecases/create_payment_intent.dart';
+import '../features/site_management/domain/usecases/get_site.dart';
+import '../features/site_management/domain/usecases/list_periods.dart';
+import '../features/site_management/domain/usecases/mark_invoice_paid.dart';
+import '../features/site_management/domain/usecases/publish_period.dart';
+import '../features/site_management/domain/usecases/run_period.dart';
+import '../core/utils/notification_service.dart';
+import '../features/site_management/presentation/controllers/site_controller.dart';
+import '../features/site_management/presentation/state/site_state.dart';
+
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw UnimplementedError('SharedPreferences must be overridden');
+});
+
+final dioProvider = Provider<Dio>((ref) {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://localhost:8000',
+      connectTimeout: const Duration(seconds: 5),
+      receiveTimeout: const Duration(seconds: 5),
+    ),
+  );
+  return dio;
+});
+
+final jwtTokenManagerProvider = Provider<JwtTokenManager>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return JwtTokenManager(prefs);
+});
+
+final apiClientProvider = Provider<ApiClient>((ref) {
+  final dio = ref.watch(dioProvider);
+  final tokenManager = ref.watch(jwtTokenManagerProvider);
+  return ApiClient(dio, tokenManager);
+});
+
+final offlineCacheProvider = Provider<OfflineCache>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return OfflineCache(prefs);
+});
+
+final siteRemoteDataSourceProvider = Provider<SiteRemoteDataSource>((ref) {
+  final client = ref.watch(apiClientProvider);
+  return SiteRemoteDataSourceImpl(client);
+});
+
+final siteLocalDataSourceProvider = Provider<SiteLocalDataSource>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  final cache = ref.watch(offlineCacheProvider);
+  return SiteLocalDataSourceImpl(prefs, cache);
+});
+
+final siteRepositoryProvider = Provider<SiteRepository>((ref) {
+  final remote = ref.watch(siteRemoteDataSourceProvider);
+  final local = ref.watch(siteLocalDataSourceProvider);
+  return SiteRepositoryImpl(remote, local);
+});
+
+final getSiteProvider = Provider<GetSite>((ref) {
+  final repository = ref.watch(siteRepositoryProvider);
+  return GetSite(repository);
+});
+
+final listPeriodsProvider = Provider<ListPeriods>((ref) {
+  final repository = ref.watch(siteRepositoryProvider);
+  return ListPeriods(repository);
+});
+
+final runPeriodProvider = Provider<RunPeriod>((ref) {
+  final repository = ref.watch(siteRepositoryProvider);
+  return RunPeriod(repository);
+});
+
+final publishPeriodProvider = Provider<PublishPeriod>((ref) {
+  final repository = ref.watch(siteRepositoryProvider);
+  return PublishPeriod(repository);
+});
+
+final createPaymentIntentProvider = Provider<CreatePaymentIntent>((ref) {
+  final repository = ref.watch(siteRepositoryProvider);
+  return CreatePaymentIntent(repository);
+});
+
+final markInvoicePaidProvider = Provider<MarkInvoicePaid>((ref) {
+  final repository = ref.watch(siteRepositoryProvider);
+  return MarkInvoicePaid(repository);
+});
+
+final firebaseMessagingProvider = Provider<FirebaseMessaging>((ref) {
+  return FirebaseMessaging.instance;
+});
+
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  final messaging = ref.watch(firebaseMessagingProvider);
+  return NotificationService(messaging);
+});
+
+final siteControllerProvider =
+    StateNotifierProvider<SiteController, SiteState>((ref) {
+  final controller = SiteController(
+    getSite: ref.watch(getSiteProvider),
+    listPeriods: ref.watch(listPeriodsProvider),
+    runPeriod: ref.watch(runPeriodProvider),
+    publishPeriod: ref.watch(publishPeriodProvider),
+    createPaymentIntent: ref.watch(createPaymentIntentProvider),
+    markInvoicePaid: ref.watch(markInvoicePaidProvider),
+    notificationService: ref.watch(notificationServiceProvider),
+  );
+  return controller;
+});

--- a/lib/features/site_management/data/datasources/site_local_data_source.dart
+++ b/lib/features/site_management/data/datasources/site_local_data_source.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../../core/cache/offline_cache.dart';
+import '../models/invoice_model.dart';
+
+abstract class SiteLocalDataSource {
+  Future<void> cacheInvoices(List<InvoiceModel> invoices);
+  Future<List<InvoiceModel>> getCachedInvoices();
+  Future<void> enqueueSync(Map<String, dynamic> payload);
+  Future<List<OfflineCacheQueueItem>> queuedSyncs();
+  Future<void> clearSyncItem(String key);
+}
+
+class SiteLocalDataSourceImpl implements SiteLocalDataSource {
+  SiteLocalDataSourceImpl(this._prefs, this._cache);
+
+  final SharedPreferences _prefs;
+  final OfflineCache _cache;
+  static const _invoiceKey = 'cached_invoices';
+
+  @override
+  Future<void> cacheInvoices(List<InvoiceModel> invoices) async {
+    await _prefs.setString(
+      _invoiceKey,
+      jsonEncode(invoices.map((invoice) => invoice.toJson()).toList()),
+    );
+  }
+
+  @override
+  Future<List<InvoiceModel>> getCachedInvoices() async {
+    final value = _prefs.getString(_invoiceKey);
+    if (value == null) {
+      return <InvoiceModel>[];
+    }
+    final decoded = jsonDecode(value) as List;
+    return decoded
+        .map((dynamic item) => InvoiceModel.fromJson(
+              Map<String, dynamic>.from(item as Map),
+            ))
+        .toList();
+  }
+
+  @override
+  Future<void> enqueueSync(Map<String, dynamic> payload) async {
+    await _cache.enqueue(payload);
+  }
+
+  @override
+  Future<List<OfflineCacheQueueItem>> queuedSyncs() async {
+    return _cache.fetch();
+  }
+
+  @override
+  Future<void> clearSyncItem(String key) async {
+    await _cache.clearItem(key);
+  }
+}

--- a/lib/features/site_management/data/datasources/site_remote_data_source.dart
+++ b/lib/features/site_management/data/datasources/site_remote_data_source.dart
@@ -1,0 +1,96 @@
+import '../../../../core/network/api_client.dart';
+import '../models/invoice_model.dart';
+import '../models/payment_model.dart';
+import '../models/period_model.dart';
+import '../models/site_model.dart';
+
+abstract class SiteRemoteDataSource {
+  Future<SiteModel> fetchSite(String siteId);
+  Future<List<PeriodModel>> listPeriods(String siteId);
+  Future<PeriodModel> upsertPeriod(PeriodModel period);
+  Future<List<InvoiceModel>> runPeriod(String siteId, PeriodModel period);
+  Future<PeriodModel> publishPeriod(String siteId, String periodId);
+  Future<PaymentIntentModel> createPaymentIntent(
+    String siteId,
+    String invoiceId,
+    String gateway,
+  );
+  Future<void> markInvoicePaid(String siteId, String invoiceId);
+}
+
+class SiteRemoteDataSourceImpl implements SiteRemoteDataSource {
+  SiteRemoteDataSourceImpl(this._client);
+
+  final ApiClient _client;
+
+  @override
+  Future<SiteModel> fetchSite(String siteId) async {
+    final response = await _client.get<Map<String, dynamic>>('/sites/$siteId');
+    return SiteModel.fromJson(response.data!);
+  }
+
+  @override
+  Future<List<PeriodModel>> listPeriods(String siteId) async {
+    final response = await _client.get<List<dynamic>>('/sites/$siteId/periods');
+    return response.data!
+        .map(
+          (dynamic item) => PeriodModel.fromJson(
+            Map<String, dynamic>.from(item as Map),
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<PeriodModel> upsertPeriod(PeriodModel period) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/sites/${period.siteId}/periods',
+      data: period.toJson(),
+    );
+    return PeriodModel.fromJson(response.data!);
+  }
+
+  @override
+  Future<List<InvoiceModel>> runPeriod(String siteId, PeriodModel period) async {
+    final response = await _client.post<List<dynamic>>(
+      '/sites/$siteId/periods/${period.id}/run',
+      data: period.toJson(),
+    );
+    return response.data!
+        .map(
+          (dynamic item) => InvoiceModel.fromJson(
+            Map<String, dynamic>.from(item as Map),
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<PeriodModel> publishPeriod(String siteId, String periodId) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/sites/$siteId/periods/$periodId/publish',
+    );
+    return PeriodModel.fromJson(response.data!);
+  }
+
+  @override
+  Future<PaymentIntentModel> createPaymentIntent(
+    String siteId,
+    String invoiceId,
+    String gateway,
+  ) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/sites/$siteId/invoices/$invoiceId/payments',
+      data: <String, dynamic>{'gateway': gateway},
+    );
+    return PaymentIntentModel.fromJson(response.data!);
+  }
+
+  @override
+  Future<void> markInvoicePaid(String siteId, String invoiceId) async {
+    await _client.put<void>(
+      '/sites/$siteId/invoices/$invoiceId',
+      data: <String, dynamic>{'status': 'paid'},
+    );
+  }
+}

--- a/lib/features/site_management/data/models/expense_model.dart
+++ b/lib/features/site_management/data/models/expense_model.dart
@@ -1,0 +1,38 @@
+import '../../domain/entities/expense.dart';
+
+class ExpenseModel extends ExpenseItem {
+  const ExpenseModel({
+    required super.id,
+    required super.name,
+    required super.amount,
+    required super.distributionType,
+    super.meterReadings = const <String, double>{},
+  });
+
+  factory ExpenseModel.fromJson(Map<String, dynamic> json) {
+    return ExpenseModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      distributionType: ExpenseDistributionType.values
+          .firstWhere(
+            (type) => type.name == (json['distribution_type'] as String),
+          ),
+      meterReadings: json['meter_readings'] == null
+          ? const <String, double>{}
+          : Map<String, double>.from(
+              (json['meter_readings'] as Map).map(
+                (key, value) => MapEntry(key as String, (value as num).toDouble()),
+              ),
+            ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'name': name,
+        'amount': amount,
+        'distribution_type': distributionType.name,
+        'meter_readings': meterReadings,
+      };
+}

--- a/lib/features/site_management/data/models/invoice_model.dart
+++ b/lib/features/site_management/data/models/invoice_model.dart
@@ -1,0 +1,53 @@
+import '../../domain/entities/invoice.dart';
+
+class InvoiceModel extends Invoice {
+  const InvoiceModel({
+    required super.id,
+    required super.periodId,
+    required super.periodName,
+    required super.unitId,
+    required super.tenantId,
+    required super.tenantName,
+    required List<InvoiceItem> super.items,
+    required super.total,
+    super.paymentStatus,
+  });
+
+  factory InvoiceModel.fromJson(Map<String, dynamic> json) {
+    return InvoiceModel(
+      id: json['id'] as String,
+      periodId: json['period_id'] as String,
+      periodName: json['period_name'] as String,
+      unitId: json['unit_id'] as String,
+      tenantId: json['tenant_id'] as String,
+      tenantName: json['tenant_name'] as String,
+      items: (json['items'] as List)
+          .map(
+            (dynamic item) => InvoiceItem(
+              description: (item as Map)['description'] as String,
+              amount: ((item)['amount'] as num).toDouble(),
+            ),
+          )
+          .toList(),
+      total: (json['total'] as num).toDouble(),
+      paymentStatus: json['payment_status'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'period_id': periodId,
+        'period_name': periodName,
+        'unit_id': unitId,
+        'tenant_id': tenantId,
+        'tenant_name': tenantName,
+        'items': items
+            .map((item) => <String, dynamic>{
+                  'description': item.description,
+                  'amount': item.amount,
+                })
+            .toList(),
+        'total': total,
+        'payment_status': paymentStatus,
+      };
+}

--- a/lib/features/site_management/data/models/payment_model.dart
+++ b/lib/features/site_management/data/models/payment_model.dart
@@ -1,0 +1,26 @@
+import '../../domain/entities/payment.dart';
+
+class PaymentIntentModel extends PaymentIntent {
+  const PaymentIntentModel({
+    required super.invoiceId,
+    required super.gateway,
+    required super.checkoutFormToken,
+    required super.redirectUrl,
+  });
+
+  factory PaymentIntentModel.fromJson(Map<String, dynamic> json) {
+    return PaymentIntentModel(
+      invoiceId: json['invoice_id'] as String,
+      gateway: json['gateway'] as String,
+      checkoutFormToken: json['checkout_form_token'] as String,
+      redirectUrl: json['redirect_url'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'invoice_id': invoiceId,
+        'gateway': gateway,
+        'checkout_form_token': checkoutFormToken,
+        'redirect_url': redirectUrl,
+      };
+}

--- a/lib/features/site_management/data/models/period_model.dart
+++ b/lib/features/site_management/data/models/period_model.dart
@@ -1,0 +1,57 @@
+import '../../domain/entities/period.dart';
+import 'expense_model.dart';
+
+class PeriodModel extends Period {
+  PeriodModel({
+    required super.id,
+    required super.name,
+    required super.siteId,
+    required List<ExpenseItem> super.expenses,
+    required super.status,
+    super.generatedInvoices = const <String>[],
+    super.createdAt,
+  });
+
+  factory PeriodModel.fromJson(Map<String, dynamic> json) {
+    return PeriodModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      siteId: json['site_id'] as String,
+      expenses: (json['expenses'] as List)
+          .map((dynamic item) => ExpenseModel.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              ))
+          .toList(),
+      status: PeriodStatus.values.firstWhere(
+        (element) => element.name == (json['status'] as String),
+        orElse: () => PeriodStatus.draft,
+      ),
+      generatedInvoices: json['generated_invoices'] == null
+          ? const <String>[]
+          : List<String>.from(json['generated_invoices'] as List),
+      createdAt: json['created_at'] != null
+          ? DateTime.parse(json['created_at'] as String)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'name': name,
+        'site_id': siteId,
+        'expenses': expenses
+            .map((item) => item is ExpenseModel
+                ? item.toJson()
+                : ExpenseModel(
+                    id: item.id,
+                    name: item.name,
+                    amount: item.amount,
+                    distributionType: item.distributionType,
+                    meterReadings: item.meterReadings,
+                  ).toJson())
+            .toList(),
+        'status': status.name,
+        'generated_invoices': generatedInvoices,
+        'created_at': createdAt?.toIso8601String(),
+      };
+}

--- a/lib/features/site_management/data/models/site_model.dart
+++ b/lib/features/site_management/data/models/site_model.dart
@@ -1,0 +1,31 @@
+import '../../domain/entities/site.dart';
+import 'unit_model.dart';
+
+class SiteModel extends Site {
+  const SiteModel({
+    required super.id,
+    required super.name,
+    required List<UnitModel> super.units,
+    required super.roles,
+  });
+
+  factory SiteModel.fromJson(Map<String, dynamic> json) {
+    return SiteModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      units: (json['units'] as List)
+          .map((dynamic item) => UnitModel.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              ))
+          .toList(),
+      roles: List<String>.from(json['roles'] as List),
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'name': name,
+        'units': units.map((unit) => (unit as UnitModel).toJson()).toList(),
+        'roles': roles,
+      };
+}

--- a/lib/features/site_management/data/models/unit_model.dart
+++ b/lib/features/site_management/data/models/unit_model.dart
@@ -1,0 +1,35 @@
+import '../../domain/entities/unit.dart';
+
+class UnitModel extends Unit {
+  const UnitModel({
+    required super.id,
+    required super.block,
+    required super.floor,
+    required super.number,
+    required super.squareMeter,
+    required super.landShare,
+    required super.tenantId,
+  });
+
+  factory UnitModel.fromJson(Map<String, dynamic> json) {
+    return UnitModel(
+      id: json['id'] as String,
+      block: json['block'] as String,
+      floor: json['floor'] as int,
+      number: json['number'] as String,
+      squareMeter: (json['square_meter'] as num).toDouble(),
+      landShare: (json['land_share'] as num).toDouble(),
+      tenantId: json['tenant_id'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'block': block,
+        'floor': floor,
+        'number': number,
+        'square_meter': squareMeter,
+        'land_share': landShare,
+        'tenant_id': tenantId,
+      };
+}

--- a/lib/features/site_management/data/repositories/site_repository_impl.dart
+++ b/lib/features/site_management/data/repositories/site_repository_impl.dart
@@ -1,0 +1,90 @@
+import '../../../../core/errors/failures.dart';
+import '../../domain/entities/invoice.dart';
+import '../../domain/entities/payment.dart';
+import '../../domain/entities/period.dart';
+import '../../domain/entities/site.dart';
+import '../../domain/repositories/site_repository.dart';
+import '../datasources/site_local_data_source.dart';
+import '../datasources/site_remote_data_source.dart';
+import '../models/period_model.dart';
+
+class SiteRepositoryImpl implements SiteRepository {
+  SiteRepositoryImpl(this.remoteDataSource, this.localDataSource);
+
+  final SiteRemoteDataSource remoteDataSource;
+  final SiteLocalDataSource localDataSource;
+
+  @override
+  Future<Site> fetchSite(String siteId) async {
+    return remoteDataSource.fetchSite(siteId);
+  }
+
+  @override
+  Future<List<Period>> listPeriods(String siteId) async {
+    return remoteDataSource.listPeriods(siteId);
+  }
+
+  @override
+  Future<Period> createOrUpdatePeriod(Period period) async {
+    final periodModel = period is PeriodModel
+        ? period
+        : PeriodModel(
+            id: period.id,
+            name: period.name,
+            siteId: period.siteId,
+            expenses: period.expenses,
+            status: period.status,
+            generatedInvoices: period.generatedInvoices,
+            createdAt: period.createdAt,
+          );
+    return remoteDataSource.upsertPeriod(periodModel);
+  }
+
+  @override
+  Future<List<Invoice>> runPeriod(String siteId, Period period) async {
+    final periodModel = period is PeriodModel
+        ? period
+        : PeriodModel(
+            id: period.id,
+            name: period.name,
+            siteId: period.siteId,
+            expenses: period.expenses,
+            status: period.status,
+            generatedInvoices: period.generatedInvoices,
+            createdAt: period.createdAt,
+          );
+    final invoices = await remoteDataSource.runPeriod(siteId, periodModel);
+    await localDataSource.cacheInvoices(invoices);
+    return invoices;
+  }
+
+  @override
+  Future<Period> publishPeriod(String siteId, String periodId) async {
+    return remoteDataSource.publishPeriod(siteId, periodId);
+  }
+
+  @override
+  Future<PaymentIntent> createPaymentIntent(
+    String siteId,
+    String invoiceId,
+    String gateway,
+  ) async {
+    return remoteDataSource.createPaymentIntent(siteId, invoiceId, gateway);
+  }
+
+  @override
+  Future<void> markInvoicePaid(String siteId, String invoiceId) async {
+    try {
+      await remoteDataSource.markInvoicePaid(siteId, invoiceId);
+    } catch (error) {
+      await localDataSource.enqueueSync(
+        <String, dynamic>{
+          'operation': 'mark_invoice_paid',
+          'site_id': siteId,
+          'invoice_id': invoiceId,
+        },
+      );
+      throw CacheFailure(message: error.toString());
+    }
+  }
+}

--- a/lib/features/site_management/domain/entities/expense.dart
+++ b/lib/features/site_management/domain/entities/expense.dart
@@ -1,0 +1,22 @@
+enum ExpenseDistributionType {
+  landShare,
+  squareMeter,
+  fixed,
+  meter,
+}
+
+class ExpenseItem {
+  const ExpenseItem({
+    required this.id,
+    required this.name,
+    required this.amount,
+    required this.distributionType,
+    this.meterReadings = const <String, double>{},
+  });
+
+  final String id;
+  final String name;
+  final double amount;
+  final ExpenseDistributionType distributionType;
+  final Map<String, double> meterReadings;
+}

--- a/lib/features/site_management/domain/entities/invoice.dart
+++ b/lib/features/site_management/domain/entities/invoice.dart
@@ -1,0 +1,45 @@
+class InvoiceItem {
+  const InvoiceItem({
+    required this.description,
+    required this.amount,
+  });
+
+  final String description;
+  final double amount;
+}
+
+class Invoice {
+  const Invoice({
+    required this.id,
+    required this.periodId,
+    required this.periodName,
+    required this.unitId,
+    required this.tenantId,
+    required this.tenantName,
+    required this.items,
+    required this.total,
+    this.paymentStatus = 'unpaid',
+  });
+
+  final String id;
+  final String periodId;
+  final String periodName;
+  final String unitId;
+  final String tenantId;
+  final String tenantName;
+  final List<InvoiceItem> items;
+  final double total;
+  final String paymentStatus;
+
+  Invoice copyWith({String? paymentStatus}) => Invoice(
+        id: id,
+        periodId: periodId,
+        periodName: periodName,
+        unitId: unitId,
+        tenantId: tenantId,
+        tenantName: tenantName,
+        items: items,
+        total: total,
+        paymentStatus: paymentStatus ?? this.paymentStatus,
+      );
+}

--- a/lib/features/site_management/domain/entities/payment.dart
+++ b/lib/features/site_management/domain/entities/payment.dart
@@ -1,0 +1,13 @@
+class PaymentIntent {
+  const PaymentIntent({
+    required this.invoiceId,
+    required this.gateway,
+    required this.checkoutFormToken,
+    required this.redirectUrl,
+  });
+
+  final String invoiceId;
+  final String gateway;
+  final String checkoutFormToken;
+  final String redirectUrl;
+}

--- a/lib/features/site_management/domain/entities/period.dart
+++ b/lib/features/site_management/domain/entities/period.dart
@@ -1,0 +1,38 @@
+import 'expense.dart';
+
+enum PeriodStatus { draft, processing, published }
+
+class Period {
+  const Period({
+    required this.id,
+    required this.name,
+    required this.siteId,
+    required this.expenses,
+    required this.status,
+    this.generatedInvoices = const <String>[],
+    this.createdAt,
+  });
+
+  final String id;
+  final String name;
+  final String siteId;
+  final List<ExpenseItem> expenses;
+  final PeriodStatus status;
+  final List<String> generatedInvoices;
+  final DateTime? createdAt;
+
+  Period copyWith({
+    PeriodStatus? status,
+    List<String>? generatedInvoices,
+  }) {
+    return Period(
+      id: id,
+      name: name,
+      siteId: siteId,
+      expenses: expenses,
+      status: status ?? this.status,
+      generatedInvoices: generatedInvoices ?? this.generatedInvoices,
+      createdAt: createdAt,
+    );
+  }
+}

--- a/lib/features/site_management/domain/entities/site.dart
+++ b/lib/features/site_management/domain/entities/site.dart
@@ -1,0 +1,15 @@
+import 'unit.dart';
+
+class Site {
+  const Site({
+    required this.id,
+    required this.name,
+    required this.units,
+    required this.roles,
+  });
+
+  final String id;
+  final String name;
+  final List<Unit> units;
+  final List<String> roles;
+}

--- a/lib/features/site_management/domain/entities/unit.dart
+++ b/lib/features/site_management/domain/entities/unit.dart
@@ -1,0 +1,19 @@
+class Unit {
+  const Unit({
+    required this.id,
+    required this.block,
+    required this.floor,
+    required this.number,
+    required this.squareMeter,
+    required this.landShare,
+    required this.tenantId,
+  });
+
+  final String id;
+  final String block;
+  final int floor;
+  final String number;
+  final double squareMeter;
+  final double landShare;
+  final String tenantId;
+}

--- a/lib/features/site_management/domain/repositories/site_repository.dart
+++ b/lib/features/site_management/domain/repositories/site_repository.dart
@@ -1,0 +1,18 @@
+import '../entities/invoice.dart';
+import '../entities/payment.dart';
+import '../entities/period.dart';
+import '../entities/site.dart';
+
+abstract class SiteRepository {
+  Future<Site> fetchSite(String siteId);
+  Future<List<Period>> listPeriods(String siteId);
+  Future<Period> createOrUpdatePeriod(Period period);
+  Future<List<Invoice>> runPeriod(String siteId, Period period);
+  Future<Period> publishPeriod(String siteId, String periodId);
+  Future<PaymentIntent> createPaymentIntent(
+    String siteId,
+    String invoiceId,
+    String gateway,
+  );
+  Future<void> markInvoicePaid(String siteId, String invoiceId);
+}

--- a/lib/features/site_management/domain/usecases/create_payment_intent.dart
+++ b/lib/features/site_management/domain/usecases/create_payment_intent.dart
@@ -1,0 +1,39 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/payment.dart';
+import '../repositories/site_repository.dart';
+
+class CreatePaymentIntentParams {
+  const CreatePaymentIntentParams({
+    required this.siteId,
+    required this.invoiceId,
+    required this.gateway,
+  });
+
+  final String siteId;
+  final String invoiceId;
+  final String gateway;
+}
+
+class CreatePaymentIntent
+    extends UseCase<PaymentIntent, CreatePaymentIntentParams> {
+  CreatePaymentIntent(this.repository);
+
+  final SiteRepository repository;
+
+  @override
+  EitherFailureOr<PaymentIntent> call(CreatePaymentIntentParams params) async {
+    try {
+      final intent = await repository.createPaymentIntent(
+        params.siteId,
+        params.invoiceId,
+        params.gateway,
+      );
+      return Right(intent);
+    } catch (error) {
+      return Left(NetworkFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/site_management/domain/usecases/get_site.dart
+++ b/lib/features/site_management/domain/usecases/get_site.dart
@@ -1,0 +1,22 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/site.dart';
+import '../repositories/site_repository.dart';
+
+class GetSite extends UseCase<Site, String> {
+  GetSite(this.repository);
+
+  final SiteRepository repository;
+
+  @override
+  EitherFailureOr<Site> call(String params) async {
+    try {
+      final site = await repository.fetchSite(params);
+      return Right(site);
+    } catch (error) {
+      return Left(NetworkFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/site_management/domain/usecases/list_periods.dart
+++ b/lib/features/site_management/domain/usecases/list_periods.dart
@@ -1,0 +1,22 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/period.dart';
+import '../repositories/site_repository.dart';
+
+class ListPeriods extends UseCase<List<Period>, String> {
+  ListPeriods(this.repository);
+
+  final SiteRepository repository;
+
+  @override
+  EitherFailureOr<List<Period>> call(String params) async {
+    try {
+      final periods = await repository.listPeriods(params);
+      return Right(periods);
+    } catch (error) {
+      return Left(NetworkFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/site_management/domain/usecases/mark_invoice_paid.dart
+++ b/lib/features/site_management/domain/usecases/mark_invoice_paid.dart
@@ -1,0 +1,31 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../repositories/site_repository.dart';
+
+class MarkInvoicePaidParams {
+  const MarkInvoicePaidParams({
+    required this.siteId,
+    required this.invoiceId,
+  });
+
+  final String siteId;
+  final String invoiceId;
+}
+
+class MarkInvoicePaid extends UseCase<void, MarkInvoicePaidParams> {
+  MarkInvoicePaid(this.repository);
+
+  final SiteRepository repository;
+
+  @override
+  EitherFailureOr<void> call(MarkInvoicePaidParams params) async {
+    try {
+      await repository.markInvoicePaid(params.siteId, params.invoiceId);
+      return const Right(null);
+    } catch (error) {
+      return Left(NetworkFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/site_management/domain/usecases/publish_period.dart
+++ b/lib/features/site_management/domain/usecases/publish_period.dart
@@ -1,0 +1,33 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/period.dart';
+import '../repositories/site_repository.dart';
+
+class PublishPeriodParams {
+  const PublishPeriodParams({
+    required this.siteId,
+    required this.periodId,
+  });
+
+  final String siteId;
+  final String periodId;
+}
+
+class PublishPeriod extends UseCase<Period, PublishPeriodParams> {
+  PublishPeriod(this.repository);
+
+  final SiteRepository repository;
+
+  @override
+  EitherFailureOr<Period> call(PublishPeriodParams params) async {
+    try {
+      final period =
+          await repository.publishPeriod(params.siteId, params.periodId);
+      return Right(period);
+    } catch (error) {
+      return Left(NetworkFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/site_management/domain/usecases/run_period.dart
+++ b/lib/features/site_management/domain/usecases/run_period.dart
@@ -1,0 +1,33 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/invoice.dart';
+import '../entities/period.dart';
+import '../repositories/site_repository.dart';
+
+class RunPeriodParams {
+  const RunPeriodParams({
+    required this.siteId,
+    required this.period,
+  });
+
+  final String siteId;
+  final Period period;
+}
+
+class RunPeriod extends UseCase<List<Invoice>, RunPeriodParams> {
+  RunPeriod(this.repository);
+
+  final SiteRepository repository;
+
+  @override
+  EitherFailureOr<List<Invoice>> call(RunPeriodParams params) async {
+    try {
+      final invoices = await repository.runPeriod(params.siteId, params.period);
+      return Right(invoices);
+    } catch (error) {
+      return Left(ValidationFailure(message: error.toString()));
+    }
+  }
+}

--- a/lib/features/site_management/presentation/controllers/site_controller.dart
+++ b/lib/features/site_management/presentation/controllers/site_controller.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../../../../core/utils/notification_service.dart';
+import '../../domain/entities/invoice.dart';
+import '../../domain/entities/period.dart';
+import '../../domain/usecases/create_payment_intent.dart';
+import '../../domain/usecases/get_site.dart';
+import '../../domain/usecases/list_periods.dart';
+import '../../domain/usecases/mark_invoice_paid.dart';
+import '../../domain/usecases/publish_period.dart';
+import '../../domain/usecases/run_period.dart';
+import '../state/site_state.dart';
+
+class SiteController extends StateNotifier<SiteState> {
+  SiteController({
+    required GetSite getSite,
+    required ListPeriods listPeriods,
+    required RunPeriod runPeriod,
+    required PublishPeriod publishPeriod,
+    required CreatePaymentIntent createPaymentIntent,
+    required MarkInvoicePaid markInvoicePaid,
+    required NotificationService notificationService,
+  })  : _getSite = getSite,
+        _listPeriods = listPeriods,
+        _runPeriod = runPeriod,
+        _publishPeriod = publishPeriod,
+        _createPaymentIntent = createPaymentIntent,
+        _markInvoicePaid = markInvoicePaid,
+        _notificationService = notificationService,
+        super(const SiteState());
+
+  final GetSite _getSite;
+  final ListPeriods _listPeriods;
+  final RunPeriod _runPeriod;
+  final PublishPeriod _publishPeriod;
+  final CreatePaymentIntent _createPaymentIntent;
+  final MarkInvoicePaid _markInvoicePaid;
+  final NotificationService _notificationService;
+
+  Future<void> loadSite(String siteId) async {
+    state = state.copyWith(isLoading: true, resetError: true);
+    final siteResult = await _getSite(siteId);
+    siteResult.fold(
+      (failure) => _setError(failure),
+      (site) async {
+        state = state.copyWith(site: site);
+        final periodsResult = await _listPeriods(siteId);
+        periodsResult.fold(
+          (failure) => _setError(failure),
+          (periods) => state = state.copyWith(
+            periods: periods,
+            isLoading: false,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> runPeriod(String siteId, Period period) async {
+    state = state.copyWith(isLoading: true, resetError: true);
+    final result = await _runPeriod(RunPeriodParams(siteId: siteId, period: period));
+    result.fold(
+      (failure) => _setError(failure),
+      (invoices) {
+        state = state.copyWith(isLoading: false, invoices: invoices);
+      },
+    );
+  }
+
+  Future<void> publishPeriod(String siteId, String periodId) async {
+    state = state.copyWith(isLoading: true, resetError: true);
+    final result = await _publishPeriod(
+      PublishPeriodParams(siteId: siteId, periodId: periodId),
+    );
+    result.fold(
+      (failure) => _setError(failure),
+      (period) {
+        final updatedPeriods = state.periods.map((existing) {
+          if (existing.id == period.id) {
+            return period;
+          }
+          return existing;
+        }).toList();
+        state = state.copyWith(isLoading: false, periods: updatedPeriods);
+      },
+    );
+  }
+
+  Future<void> collectPayment(
+    String siteId,
+    String invoiceId,
+    String gateway,
+  ) async {
+    state = state.copyWith(isLoading: true, resetError: true);
+    final result = await _createPaymentIntent(
+      CreatePaymentIntentParams(
+        siteId: siteId,
+        invoiceId: invoiceId,
+        gateway: gateway,
+      ),
+    );
+    result.fold(
+      (failure) => _setError(failure),
+      (intent) async {
+        final updatedInvoices = state.invoices.map((invoice) {
+          if (invoice.id == intent.invoiceId) {
+            return invoice.copyWith(paymentStatus: 'processing');
+          }
+          return invoice;
+        }).toList();
+        state = state.copyWith(isLoading: false, invoices: updatedInvoices);
+        await _notificationService.sendLocalLog('Ödeme başlatıldı: ${intent.invoiceId}');
+      },
+    );
+  }
+
+  Future<void> markInvoicePaid(String siteId, String invoiceId) async {
+    final result = await _markInvoicePaid(
+      MarkInvoicePaidParams(siteId: siteId, invoiceId: invoiceId),
+    );
+    result.fold(
+      (failure) => _setError(failure),
+      (_) async {
+        final updatedInvoices = state.invoices.map((invoice) {
+          if (invoice.id == invoiceId) {
+            return invoice.copyWith(paymentStatus: 'paid');
+          }
+          return invoice;
+        }).toList();
+        state = state.copyWith(invoices: updatedInvoices);
+        await _notificationService.sendLocalLog('Fatura ödendi: $invoiceId');
+      },
+    );
+  }
+
+  void _setError(Failure failure) {
+    state = state.copyWith(
+      isLoading: false,
+      errorMessage: failure.message ?? 'Beklenmeyen bir hata oluştu',
+    );
+  }
+}

--- a/lib/features/site_management/presentation/state/site_state.dart
+++ b/lib/features/site_management/presentation/state/site_state.dart
@@ -1,0 +1,36 @@
+import '../../domain/entities/invoice.dart';
+import '../../domain/entities/period.dart';
+import '../../domain/entities/site.dart';
+
+class SiteState {
+  const SiteState({
+    this.isLoading = false,
+    this.site,
+    this.periods = const <Period>[],
+    this.invoices = const <Invoice>[],
+    this.errorMessage,
+  });
+
+  final bool isLoading;
+  final Site? site;
+  final List<Period> periods;
+  final List<Invoice> invoices;
+  final String? errorMessage;
+
+  SiteState copyWith({
+    bool? isLoading,
+    Site? site,
+    List<Period>? periods,
+    List<Invoice>? invoices,
+    String? errorMessage,
+    bool resetError = false,
+  }) {
+    return SiteState(
+      isLoading: isLoading ?? this.isLoading,
+      site: site ?? this.site,
+      periods: periods ?? this.periods,
+      invoices: invoices ?? this.invoices,
+      errorMessage: resetError ? null : errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,22 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'app.dart';
+import 'di/providers.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  await Firebase.initializeApp();
+
+  runApp(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: const SiteApp(),
+    ),
+  );
+}

--- a/mock_api/server.py
+++ b/mock_api/server.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="Mock Site & Aidat API")
+
+
+@dataclass
+class Unit:
+    id: str
+    block: str
+    floor: int
+    number: str
+    square_meter: float
+    land_share: float
+    tenant_id: str
+
+
+@dataclass
+class Period:
+    id: str
+    name: str
+    site_id: str
+    status: str
+    expenses: List[Dict]
+    generated_invoices: List[str]
+    created_at: datetime
+
+
+@dataclass
+class Invoice:
+    id: str
+    period_id: str
+    period_name: str
+    unit_id: str
+    tenant_id: str
+    tenant_name: str
+    items: List[Dict]
+    total: float
+    payment_status: str
+
+
+class PaymentIntent(BaseModel):
+    invoice_id: str
+    gateway: str
+    checkout_form_token: str
+    redirect_url: str
+
+
+def _mock_units() -> List[Unit]:
+    return [
+        Unit(
+            id="unit-1",
+            block="A",
+            floor=1,
+            number="1",
+            square_meter=110,
+            land_share=10,
+            tenant_id="tenant-1",
+        ),
+        Unit(
+            id="unit-2",
+            block="A",
+            floor=2,
+            number="2",
+            square_meter=95,
+            land_share=8,
+            tenant_id="tenant-2",
+        ),
+    ]
+
+
+SITE = {
+    "id": "demo-site",
+    "name": "Demo Sitesi",
+    "roles": ["superadmin", "site_yoneticisi", "muhasebe", "personel", "sakin"],
+    "units": [asdict(unit) for unit in _mock_units()],
+}
+
+PERIODS: Dict[str, Period] = {}
+INVOICES: Dict[str, Invoice] = {}
+
+
+@app.get("/sites/{site_id}")
+def get_site(site_id: str):
+    if site_id != SITE["id"]:
+        raise HTTPException(status_code=404, detail="Site bulunamadı")
+    return SITE
+
+
+@app.get("/sites/{site_id}/periods")
+def list_periods(site_id: str):
+    return [asdict(period) for period in PERIODS.values() if period.site_id == site_id]
+
+
+@app.post("/sites/{site_id}/periods")
+def upsert_period(site_id: str, payload: Dict):
+    period_id = payload.get("id") or str(uuid.uuid4())
+    period = Period(
+        id=period_id,
+        name=payload["name"],
+        site_id=site_id,
+        status=payload.get("status", "draft"),
+        expenses=payload.get("expenses", []),
+        generated_invoices=payload.get("generated_invoices", []),
+        created_at=datetime.utcnow(),
+    )
+    PERIODS[period_id] = period
+    return asdict(period)
+
+
+@app.post("/sites/{site_id}/periods/{period_id}/run")
+def run_period(site_id: str, period_id: str, payload: Dict):
+    period = PERIODS.get(period_id)
+    if not period:
+        period = Period(
+            id=period_id,
+            name=payload.get("name", "Yeni Dönem"),
+            site_id=site_id,
+            status="processing",
+            expenses=payload.get("expenses", []),
+            generated_invoices=[],
+            created_at=datetime.utcnow(),
+        )
+        PERIODS[period_id] = period
+
+    invoices: List[Dict] = []
+    total_land_share = sum(unit["land_share"] for unit in SITE["units"])
+    total_square = sum(unit["square_meter"] for unit in SITE["units"])
+
+    for unit in SITE["units"]:
+        items = []
+        total_amount = 0.0
+        for expense in payload.get("expenses", []):
+            dist_type = expense["distribution_type"]
+            amount = float(expense["amount"])
+            if dist_type == "landShare":
+                share = unit["land_share"] / total_land_share
+                allocated = amount * share
+            elif dist_type == "squareMeter":
+                share = unit["square_meter"] / total_square
+                allocated = amount * share
+            elif dist_type == "fixed":
+                allocated = amount / len(SITE["units"])
+            else:
+                readings = expense.get("meter_readings", {})
+                unit_reading = float(readings.get(unit["id"], 0))
+                total_readings = sum(float(value) for value in readings.values()) or 1
+                allocated = amount * unit_reading / total_readings
+            items.append({
+                "description": expense["name"],
+                "amount": round(allocated, 2),
+            })
+            total_amount += allocated
+        invoice_id = str(uuid.uuid4())
+        invoice = Invoice(
+            id=invoice_id,
+            period_id=period.id,
+            period_name=period.name,
+            unit_id=unit["id"],
+            tenant_id=unit["tenant_id"],
+            tenant_name=f"Sakin {unit['number']}",
+            items=items,
+            total=round(total_amount, 2),
+            payment_status="unpaid",
+        )
+        INVOICES[invoice_id] = invoice
+        invoices.append(asdict(invoice))
+
+    period.generated_invoices = [invoice["id"] for invoice in invoices]
+    period.status = "processing"
+    return invoices
+
+
+@app.post("/sites/{site_id}/periods/{period_id}/publish")
+def publish_period(site_id: str, period_id: str):
+    period = PERIODS.get(period_id)
+    if not period:
+        raise HTTPException(status_code=404, detail="Dönem bulunamadı")
+    period.status = "published"
+    return asdict(period)
+
+
+@app.post("/sites/{site_id}/invoices/{invoice_id}/payments")
+def create_payment(site_id: str, invoice_id: str, payload: Dict):
+    invoice = INVOICES.get(invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Fatura bulunamadı")
+    gateway = payload.get("gateway", "iyzico")
+    return PaymentIntent(
+        invoice_id=invoice.id,
+        gateway=gateway,
+        checkout_form_token=str(uuid.uuid4()),
+        redirect_url=f"https://{gateway}.example.com/pay/{invoice.id}",
+    )
+
+
+@app.put("/sites/{site_id}/invoices/{invoice_id}")
+def mark_invoice_paid(site_id: str, invoice_id: str, payload: Dict):
+    invoice = INVOICES.get(invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Fatura bulunamadı")
+    invoice.payment_status = payload.get("status", "paid")
+    INVOICES[invoice_id] = invoice
+    return {"status": invoice.payment_status}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,41 @@
+name: site_aidat_management
+description: Multi-tenant site & dues management mobile app built with Flutter and Clean Architecture.
+version: 1.0.0+1
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  dio: ^5.4.0
+  freezed_annotation: ^2.4.1
+  json_annotation: ^4.9.0
+  flutter_riverpod: ^2.4.0
+  uuid: ^4.2.1
+  shared_preferences: ^2.2.2
+  connectivity_plus: ^5.0.2
+  collection: ^1.18.0
+  intl: ^0.18.1
+  syncfusion_flutter_pdf: ^24.1.41
+  firebase_core: ^2.25.4
+  dartz: ^0.10.1
+  firebase_messaging: ^14.7.10
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  build_runner: ^2.4.8
+  freezed: ^2.4.6
+  json_serializable: ^6.7.1
+  mocktail: ^1.0.3
+  very_good_analysis: ^5.1.0
+
+flutter:
+  uses-material-design: true
+
+  assets:
+    - assets/fonts/

--- a/test/features/site_management/data/offline_cache_test.dart
+++ b/test/features/site_management/data/offline_cache_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:site_aidat_management/core/cache/offline_cache.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('OfflineCache', () {
+    test('enqueue and fetch should persist payloads', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final cache = OfflineCache(prefs);
+
+      await cache.enqueue({'operation': 'mark_invoice_paid'});
+      await cache.enqueue({'operation': 'sync_invoice'});
+
+      final queue = await cache.fetch();
+
+      expect(queue.length, 2);
+      expect(queue.first.payload['operation'], 'mark_invoice_paid');
+
+      await cache.clearItem(queue.first.key);
+      final queueAfterClear = await cache.fetch();
+      expect(queueAfterClear.length, 1);
+    });
+  });
+}

--- a/test/features/site_management/domain/usecases/run_period_test.dart
+++ b/test/features/site_management/domain/usecases/run_period_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:site_aidat_management/features/site_management/domain/entities/expense.dart';
+import 'package:site_aidat_management/features/site_management/domain/entities/invoice.dart';
+import 'package:site_aidat_management/features/site_management/domain/entities/period.dart';
+import 'package:site_aidat_management/features/site_management/domain/repositories/site_repository.dart';
+import 'package:site_aidat_management/features/site_management/domain/usecases/run_period.dart';
+
+class _MockSiteRepository extends Mock implements SiteRepository {}
+
+void main() {
+  group('RunPeriod', () {
+    late _MockSiteRepository repository;
+    late RunPeriod useCase;
+
+    setUp(() {
+      repository = _MockSiteRepository();
+      useCase = RunPeriod(repository);
+    });
+
+    test('should call repository with correct parameters', () async {
+      final period = Period(
+        id: 'period-1',
+        name: 'Ocak 2024',
+        siteId: 'demo-site',
+        expenses: const [
+          ExpenseItem(
+            id: 'exp-1',
+            name: 'Güvenlik',
+            amount: 1000,
+            distributionType: ExpenseDistributionType.fixed,
+          ),
+        ],
+        status: PeriodStatus.draft,
+      );
+      final invoices = [
+        Invoice(
+          id: 'inv-1',
+          periodId: 'period-1',
+          periodName: 'Ocak 2024',
+          unitId: 'unit-1',
+          tenantId: 'tenant-1',
+          tenantName: 'Sakin 1',
+          items: const [
+            InvoiceItem(description: 'Güvenlik', amount: 500),
+          ],
+          total: 500,
+        ),
+      ];
+
+      when(() => repository.runPeriod('demo-site', period))
+          .thenAnswer((_) async => invoices);
+
+      final result = await useCase(const RunPeriodParams(
+        siteId: 'demo-site',
+        period: period,
+      ));
+
+      expect(result.isRight(), isTrue);
+      expect(result.getOrElse(() => []), equals(invoices));
+      verify(() => repository.runPeriod('demo-site', period)).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold a Flutter Clean Architecture app for multi-tenant site and dues management with Riverpod state management
- implement domain, data, and core layers covering period workflows, invoicing, payments, PDF generation, JWT auth, notifications, and offline cache
- add FastAPI mock server, tests, and documentation describing setup, features, and testing

## Testing
- not run (environment lacks Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68d951c8e064832890d5bbbf7f20af64